### PR TITLE
updated to use Open3 to run instead of mixlib::shellout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,3 @@ group :development do
 end
 
 gem 'english', '~> 0.8.0'
-gem 'mixlib-shellout', '~> 3.2', '>= 3.2.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kitchen-yansible-pusher (0.3.4)
+    kitchen-yansible-pusher (0.4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -50,7 +50,7 @@ GEM
     multi_json (1.15.0)
     net-scp (4.0.0)
       net-ssh (>= 2.6.5, < 8.0.0)
-    net-ssh (7.2.3)
+    net-ssh (7.3.0)
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
     nori (2.7.1)
@@ -58,9 +58,9 @@ GEM
     pastel (0.8.0)
       tty-color (~> 0.5)
     rake (13.2.1)
-    rbs (3.5.3)
+    rbs (3.6.1)
       logger
-    rexml (3.3.7)
+    rexml (3.3.8)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -70,7 +70,7 @@ GEM
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.1)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
@@ -144,7 +144,6 @@ DEPENDENCIES
   kitchen-docker (~> 3.0)
   kitchen-vagrant (~> 2.0, >= 2.0.1)
   kitchen-yansible-pusher!
-  mixlib-shellout (~> 3.2, >= 3.2.8)
   rake (~> 13.0)
   rbs (~> 3.5, >= 3.5.3)
   rspec (~> 3.0)

--- a/lib/kitchen/yansible/pusher/version.rb
+++ b/lib/kitchen/yansible/pusher/version.rb
@@ -3,7 +3,7 @@
 module Kitchen
   module Yansible
     module Pusher
-      VERSION = "0.3.4"
+      VERSION = "0.4.0"
     end
   end
 end

--- a/spec/integration/yansible_pusher_integration_spec.rb
+++ b/spec/integration/yansible_pusher_integration_spec.rb
@@ -57,9 +57,8 @@ describe 'YansiblePusher Integration' do
       # Read the log file
       log_content = File.read(log_file)
 
-      # Perform checks on the log content
-      expect(log_content).to include('Running Ansible Playbook')
-      expect(log_content).to include('Ansible Playbook Complete!')
+      # Verify that output indicates no failures
+      expect(log_content).to include('failed=0')
 
       # Check for the correct playbook path
       expect(log_content).to include('playbooks/playbook.yaml')


### PR DESCRIPTION
Noticed that `Mixlib::ShellOut` was having trouble with Python forks for some reason.

Decided to remove it, and switch to Open3(which is in Ruby standard lib) so I can forward output to logs located in `.kitchen/logs/<suite_name>.log` as well as the terminal at the same time - which was the original motivator to use Mixlib. It's unclear what is causing the issue using MixLib but after reviewing other provisioners like SaltStack, Puppet, etc, none of them are using it either. 